### PR TITLE
Habya 2025: Add utils to give age in years

### DIFF
--- a/src/lib/utils-common/ageUtils.ts
+++ b/src/lib/utils-common/ageUtils.ts
@@ -1,0 +1,48 @@
+export function parseEnvDate(key: string): Date {
+    const value = process.env[key];
+    if (!value) {
+      throw new Error(`Environment variable ${key} is not defined`);
+    }
+    return new Date(value);
+  }
+  
+  const TOURNAMENT_DAY1 = parseEnvDate('TOURNAMENT_DAY1');
+  const TOURNAMENT_DAY2 = parseEnvDate('TOURNAMENT_DAY2');
+  
+  /**
+   * Returns age in years on a specific date.
+   */
+  export function calculateAgeOn(dateOfBirth: Date, onDate: Date): number {
+    const dob = new Date(dateOfBirth);
+    let age = onDate.getFullYear() - dob.getFullYear();
+    const birthdayPassed =
+      onDate.getMonth() > dob.getMonth() ||
+      (onDate.getMonth() === dob.getMonth() && onDate.getDate() >= dob.getDate());
+    return birthdayPassed ? age : age - 1;
+  }
+  
+  export function isAgedBelow16(dob: Date): boolean {
+    const age = calculateAgeOn(dob, TOURNAMENT_DAY2);
+    console.log(`Age on ${TOURNAMENT_DAY2.toDateString()}: ${age}`);
+    return age < 16;
+  }
+  
+  export function isAgedAtLeast(dob: Date, minAge: number): boolean {
+    const age = calculateAgeOn(dob, TOURNAMENT_DAY1);
+    console.log(`Age on ${TOURNAMENT_DAY1.toDateString()}: ${age}`);
+    return age >= minAge;
+  }
+  
+  // Aliases for 35+, 50+, 60+
+  export function isAgedAbove35(dob: Date): boolean {
+    return isAgedAtLeast(dob, 35);
+  }
+  
+  export function isAgedAbove50(dob: Date): boolean {
+    return isAgedAtLeast(dob, 50);
+  }
+  
+  export function isAgedAbove60(dob: Date): boolean {
+    return isAgedAtLeast(dob, 60);
+  }
+  


### PR DESCRIPTION
Added a utility function calculateAgeOn to compute a person's age on this year's tournament date. This will support age-based eligibility checks across various tournament events.