### PR TITLE
Habya 2025: Middleware redesign and enable /register route 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,5 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 1. Additional calls happening in Home page due to useEffect in providers - triggering /sign-in followed by /api/verify-token
 
 2. Reaching profile-setup after logging in or even edit profile enablement
+
+3. After clearing cookie or logout, we need to set the redux state to null as well. It is easily done in client side. Do it in server side as well. Otherwise, upon redirection, it directly goes to OTP input page. 

--- a/components.json
+++ b/components.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.js",
+    "css": "src/app/styles/globals.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "iconLibrary": "lucide"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,18 @@
       "version": "0.1.0",
       "dependencies": {
         "@prisma/client": "^6.8.2",
+        "@radix-ui/react-switch": "^1.2.5",
         "@reduxjs/toolkit": "^2.7.0",
         "@tailwindcss/postcss": "^4.1.4",
         "animate.css": "^4.1.1",
         "axios": "^1.8.4",
+        "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cookie": "^1.0.2",
         "firebase": "^11.6.0",
         "firebase-admin": "^13.4.0",
         "framer-motion": "^12.15.0",
+        "jose": "^6.0.11",
         "lucide-react": "^0.511.0",
         "mongodb": "^6.16.0",
         "mongoose": "^8.13.2",
@@ -26,7 +29,8 @@
         "react-dom": "^19.0.0",
         "react-hot-toast": "^2.5.2",
         "react-icons": "^5.5.0",
-        "react-redux": "^9.2.0"
+        "react-redux": "^9.2.0",
+        "tailwind-merge": "^3.3.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -40,6 +44,7 @@
         "postcss-cli": "^11.0.1",
         "prisma": "^6.8.2",
         "tailwindcss": "^4.1.4",
+        "tw-animate-css": "^1.3.2",
         "typescript": "^5"
       }
     },
@@ -1875,6 +1880,197 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
+      "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.5.tgz",
+      "integrity": "sha512-5ijLkak6ZMylXsaImpZ8u4Rlf5grRmoc0p0QeX9VJtlrM4f5m3nCTX8tWga/zOA8PZYIR/t0p2Mnvd7InrJ6yQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.8.2.tgz",
@@ -2364,7 +2560,7 @@
       "version": "19.1.5",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.5.tgz",
       "integrity": "sha512-CMCjrWucUBZvohgZxkjd6S9h0nZxXjzus6yDfUb+xLxYM7VvjKNH1tQrE9GWLql1XoOP4/Ds3bwFqShHUYraGg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -3656,6 +3852,18 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
       }
     },
     "node_modules/client-only": {
@@ -6124,9 +6332,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.15.9",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
-      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.11.tgz",
+      "integrity": "sha512-QxG7EaliDARm1O1S8BGakqncGT9s25bKL1WSf6/oa17Tkqwi8D2ZNglqCF+DsYF88/rV66Q/Q2mFAy697E1DUg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -6293,6 +6501,15 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/jwks-rsa/node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/jws": {
@@ -8658,6 +8875,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tailwind-merge": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.0.tgz",
+      "integrity": "sha512-fyW/pEfcQSiigd5SNn0nApUOxx0zB/dm6UDU/rEwc2c3sX2smWUNbapHv+QRqLGVp9GWX3THIa7MUGPo+YkDzQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.8.tgz",
@@ -8865,6 +9092,16 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tw-animate-css": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.3.2.tgz",
+      "integrity": "sha512-khGYcg4sHWFWcjpiWvy0KN0Bd6yVy6Ecc4r9ZP2u7FV+n4/Fp8MQscCWJkM0KMIRvrpGyKpIQnIbEd1hrewdeg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Wombosvideo"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -10,15 +10,18 @@
   },
   "dependencies": {
     "@prisma/client": "^6.8.2",
+    "@radix-ui/react-switch": "^1.2.5",
     "@reduxjs/toolkit": "^2.7.0",
     "@tailwindcss/postcss": "^4.1.4",
     "animate.css": "^4.1.1",
     "axios": "^1.8.4",
+    "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cookie": "^1.0.2",
     "firebase": "^11.6.0",
     "firebase-admin": "^13.4.0",
     "framer-motion": "^12.15.0",
+    "jose": "^6.0.11",
     "lucide-react": "^0.511.0",
     "mongodb": "^6.16.0",
     "mongoose": "^8.13.2",
@@ -27,7 +30,8 @@
     "react-dom": "^19.0.0",
     "react-hot-toast": "^2.5.2",
     "react-icons": "^5.5.0",
-    "react-redux": "^9.2.0"
+    "react-redux": "^9.2.0",
+    "tailwind-merge": "^3.3.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -41,6 +45,7 @@
     "postcss-cli": "^11.0.1",
     "prisma": "^6.8.2",
     "tailwindcss": "^4.1.4",
+    "tw-animate-css": "^1.3.2",
     "typescript": "^5"
   }
 }

--- a/src/app/api/auth/create-user/route.ts
+++ b/src/app/api/auth/create-user/route.ts
@@ -27,9 +27,19 @@ export async function POST(req: NextRequest) {
       data: { phone, name, gender, dob: new Date(dob) },
     });
 
-    const token = jwt.sign({ id: user.id, phone: user.phone }, JWT_SECRET, {
-      expiresIn: "7d",
-    });
+    const token = jwt.sign(
+      {
+        id: user.id,
+        name: user.name,
+        phone: user.phone,
+        dob: user.dob,
+        gender: user.gender,
+      },
+      JWT_SECRET,
+      {
+        expiresIn: "7d",
+      }
+    );
 
     const response = NextResponse.json({
       status: "created",
@@ -37,6 +47,8 @@ export async function POST(req: NextRequest) {
         id: user.id,
         name: user.name,
         phone: user.phone,
+        dob: user.dob,
+        gender: user.gender,
       },
     });
 
@@ -53,6 +65,6 @@ export async function POST(req: NextRequest) {
 
     return response;
   } catch (err) {
-    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+    return NextResponse.json({ error: "Internal error - user creation failed" }, { status: 500 });
   }
 }

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -24,9 +24,19 @@ export async function POST(req: NextRequest) {
     });
 
     if (user) {
-      const token = jwt.sign({ id: user.id, phone: user.phone }, JWT_SECRET, {
-        expiresIn: "7d",
-      });
+      const token = jwt.sign(
+        {
+          id: user.id,
+          name: user.name,
+          phone: user.phone,
+          dob: user.dob,
+          gender: user.gender,
+        },
+        JWT_SECRET,
+        {
+          expiresIn: "7d",
+        }
+      );
 
       const response = NextResponse.json({ status: "logged-in", user });
       response.headers.set(
@@ -46,7 +56,7 @@ export async function POST(req: NextRequest) {
     }
   } catch (err) {
     return NextResponse.json(
-      { error: "Internal server error" },
+      { error: "Internal server error - Login failed" },
       { status: 500 }
     );
   }

--- a/src/app/api/auth/verify-token/route.ts
+++ b/src/app/api/auth/verify-token/route.ts
@@ -13,7 +13,9 @@ export async function GET(req: Request & { cookies: { get: (key: string) => { va
   }
 
   try {
+    console.log("Decoding in verify token: ");
     const decoded = jwt.verify(token, JWT_SECRET) as { id: string };
+    console.log("Post: Decoding in verify token: ", decoded);
     // TO-DO: Check what happens if token fails. What happens to 'decoded'
     const user = await prisma.users.findUnique({
       where: { id: Number(decoded.id) },
@@ -32,12 +34,10 @@ export async function GET(req: Request & { cookies: { get: (key: string) => { va
 
     // Add user info to response headers
     const response = NextResponse.json({ user });
-    response.headers.set("x-user-id", user.id.toString());
-    response.headers.set("x-user-gender", user.gender);
-    response.headers.set("x-user-dob", user.dob.toISOString());
 
     return response;
   } catch (err) {
+    console.log("Failed in verify token: ");
     return NextResponse.json(
       { error: "Invalid or expired token" },
       { status: 401 }

--- a/src/app/api/user/events-eligible/route.ts
+++ b/src/app/api/user/events-eligible/route.ts
@@ -3,23 +3,36 @@ import prisma from '@/lib/prisma/prisma';
 import { isPlayerEligible, type Player } from '@/lib/events-utils/eligibilityUtils';
 import { type Gender } from '@/lib/events-utils/eventRules/types';
 import { eventRules } from '@/lib/events-utils/eventRules';
+import { jwtVerify } from 'jose';
+
+interface TokenPayload {
+  id: number;
+  dob: string;
+  gender: string;
+  phone?: string;
+  name?: string;
+}
+
+const JWT_SECRET = process.env.JWT_SECRET!;
+const encoder = new TextEncoder();
 
 export async function GET(req: NextRequest) {
   try {
-    const userIdRaw = req.headers.get('x-user-id');
-    const userDobRaw = req.headers.get('x-user-dob');
-    const userGenderRaw = req.headers.get('x-user-gender');
+    const token = req.cookies.get("token")?.value;
 
-    if (!userIdRaw || !userDobRaw || !userGenderRaw) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    if (!token) {
+      return NextResponse.json({ error: 'Unauthorized: No token' }, { status: 401 });
     }
 
-    const userId = Number(userIdRaw);
-    const dob = new Date(userDobRaw);
-    const gender = userGenderRaw.toLowerCase();
+    const { payload } = await jwtVerify(token, encoder.encode(JWT_SECRET))  as { payload: TokenPayload };
+    console.log("✅ Token verified in API route:", payload);
+
+    const userId = Number(payload.id);
+    const dob = new Date(payload.dob);
+    const gender = String(payload.gender).toLowerCase();
 
     if (isNaN(userId) || isNaN(dob.getTime()) || !['male', 'female'].includes(gender)) {
-      return NextResponse.json({ error: 'Invalid user info' }, { status: 400 });
+      return NextResponse.json({ error: 'Invalid user info in token' }, { status: 400 });
     }
 
     const player: Player = {
@@ -55,7 +68,7 @@ export async function GET(req: NextRequest) {
 
     return NextResponse.json({ eligibleEvents });
   } catch (error) {
-    console.error('Error in /api/user/events-eligible:', error);
+    console.error('❌ Error in /api/user/events-eligible:', error);
     return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
   }
 }

--- a/src/app/menu/buy-food/page.tsx
+++ b/src/app/menu/buy-food/page.tsx
@@ -6,10 +6,16 @@ export default function MyRegistrationsPage() {
       <Navbar />
 
       <div className="flex flex-col justify-center items-center h-[calc(100vh-4rem)] px-4">
-        <h1 className="text-4xl sm:text-6xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-teal-600 to-blue-700 text-center">
+        <h1
+          className="text-4xl sm:text-6xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-teal-600 to-blue-700 text-center"
+          style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
+        >
           🚧 Page Under Construction
         </h1>
-        <p className="mt-4 text-lg sm:text-xl text-center max-w-xl italic">
+        <p
+          className="mt-4 text-2xl sm:text-xl text-center max-w-xl italic"
+          style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
+        >
           We’re working hard to bring this page to life. Please check back soon!
         </p>
       </div>

--- a/src/app/menu/buy-shirt/page.tsx
+++ b/src/app/menu/buy-shirt/page.tsx
@@ -6,10 +6,16 @@ export default function MyRegistrationsPage() {
       <Navbar />
 
       <div className="flex flex-col justify-center items-center h-[calc(100vh-4rem)] px-4">
-        <h1 className="text-4xl sm:text-6xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-teal-600 to-blue-700 text-center">
+        <h1
+          className="text-4xl sm:text-6xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-teal-600 to-blue-700 text-center"
+          style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
+        >
           🚧 Page Under Construction
         </h1>
-        <p className="mt-4 text-lg sm:text-xl text-center max-w-xl italic">
+        <p
+          className="mt-4 text-2xl sm:text-xl text-center max-w-xl italic"
+          style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
+        >
           We’re working hard to bring this page to life. Please check back soon!
         </p>
       </div>

--- a/src/app/menu/my-registrations/page.tsx
+++ b/src/app/menu/my-registrations/page.tsx
@@ -6,10 +6,16 @@ export default function MyRegistrationsPage() {
       <Navbar />
 
       <div className="flex flex-col justify-center items-center h-[calc(100vh-4rem)] px-4">
-        <h1 className="text-4xl sm:text-6xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-teal-600 to-blue-700 text-center">
+        <h1
+          className="text-4xl sm:text-6xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-teal-600 to-blue-700 text-center"
+          style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
+        >
           🚧 Page Under Construction
         </h1>
-        <p className="mt-4 text-lg sm:text-xl text-center max-w-xl italic">
+        <p
+          className="mt-4 text-2xl sm:text-xl text-center max-w-xl italic"
+          style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
+        >
           We’re working hard to bring this page to life. Please check back soon!
         </p>
       </div>

--- a/src/app/menu/register/page.tsx
+++ b/src/app/menu/register/page.tsx
@@ -1,17 +1,100 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import EventToggleCard from "@/components/register/EventCard";
 import Navbar from "@/components/navbar/Navbar";
 
-export default function MyRegistrationsPage() {
+type Event = {
+  id: string;
+  name: string;
+  isRegistered: boolean;
+};
+
+export default function EventsPage() {
+  const [events, setEvents] = useState<Event[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    async function fetchEvents() {
+      setLoading(true);
+      try {
+        console.log("Calling events-eligible API");
+        const res = await fetch("/api/user/events-eligible");
+
+        if (!res.ok) throw new Error("Failed to fetch events");
+
+        const data = await res.json();
+
+        if (data?.eligibleEvents?.length === 0) {
+          setEvents([]);
+        } else {
+          setEvents(data.eligibleEvents);
+        }
+
+        setError(false);
+      } catch (e) {
+        console.error("Error fetching events:", e);
+        setError(true);
+        setEvents(null);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchEvents();
+  }, []);
+
   return (
     <div className="min-h-screen bg-gradient-to-r from-teal-100 to-blue-200 text-gray-800">
       <Navbar />
 
-      <div className="flex flex-col justify-center items-center h-[calc(100vh-4rem)] px-4">
-        <h1 className="text-4xl sm:text-6xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-teal-600 to-blue-700 text-center">
-          🚧 Page Under Construction
+      <div className="max-w-3xl mx-auto px-4 py-12">
+        <h1
+          className="text-3xl sm:text-4xl font-bold mb-6 text-center text-transparent bg-clip-text bg-gradient-to-r from-teal-500 to-blue-600"
+          style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
+        >
+          Events you are eligible for:
         </h1>
-        <p className="mt-4 text-lg sm:text-xl text-center max-w-xl italic">
-          We’re working hard to bring this page to life. Please check back soon!
-        </p>
+
+        {loading && (
+          <p className="text-center text-lg italic animate-pulse">
+            Loading events...
+          </p>
+        )}
+
+        {error && (
+          <p className="text-center text-red-600 text-lg">
+            Something went wrong while fetching events. Please try again later.
+          </p>
+        )}
+
+        {!loading && events && events.length === 0 && (
+          <p className="text-center text-gray-600 text-lg italic">
+            🎉 You are not eligible for any events at the moment. Stay tuned!
+          </p>
+        )}
+
+        {!loading && events && events.length > 0 && (
+          <div className="space-y-4">
+            {events.map((event) => (
+              <EventToggleCard
+                key={event.id}
+                name={event.name}
+                selected={event.isRegistered}
+                isRegistered={event.isRegistered}
+                onToggle={(checked) => {
+                  console.log(
+                    `${checked ? "Added" : "Removed"}: ${event.name} (${
+                      event.id
+                    })`
+                  );
+                  // You can later add API call to register/unregister here
+                }}
+              />
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/app/menu/sponsor/page.tsx
+++ b/src/app/menu/sponsor/page.tsx
@@ -6,10 +6,16 @@ export default function MyRegistrationsPage() {
       <Navbar />
 
       <div className="flex flex-col justify-center items-center h-[calc(100vh-4rem)] px-4">
-        <h1 className="text-4xl sm:text-6xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-teal-600 to-blue-700 text-center">
+        <h1
+          className="text-4xl sm:text-6xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-teal-600 to-blue-700 text-center"
+          style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
+        >
           🚧 Page Under Construction
         </h1>
-        <p className="mt-4 text-lg sm:text-xl text-center max-w-xl italic">
+        <p
+          className="mt-4 text-2xl sm:text-xl text-center max-w-xl italic"
+          style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
+        >
           We’re working hard to bring this page to life. Please check back soon!
         </p>
       </div>

--- a/src/app/styles/globals.css
+++ b/src/app/styles/globals.css
@@ -1,5 +1,8 @@
 @import url('https://fonts.googleapis.com/css2?family=Alumni+Sans+Pinstripe:ital@0;1&family=Ephesis&display=swap');
 @import "tailwindcss";
+@import "tw-animate-css";
+
+@custom-variant dark (&:is(.dark *));
 
 @keyframes zoomInOut {
     0% {
@@ -12,8 +15,124 @@
       transform: scale(1);
     }
   }
-  
+
   .zoom-in-out {
     animation: zoomInOut 0.5s ease-in-out;
   }
+
+  @theme inline {
+    --radius-sm: calc(var(--radius) - 4px);
+    --radius-md: calc(var(--radius) - 2px);
+    --radius-lg: var(--radius);
+    --radius-xl: calc(var(--radius) + 4px);
+    --color-background: var(--background);
+    --color-foreground: var(--foreground);
+    --color-card: var(--card);
+    --color-card-foreground: var(--card-foreground);
+    --color-popover: var(--popover);
+    --color-popover-foreground: var(--popover-foreground);
+    --color-primary: var(--primary);
+    --color-primary-foreground: var(--primary-foreground);
+    --color-secondary: var(--secondary);
+    --color-secondary-foreground: var(--secondary-foreground);
+    --color-muted: var(--muted);
+    --color-muted-foreground: var(--muted-foreground);
+    --color-accent: var(--accent);
+    --color-accent-foreground: var(--accent-foreground);
+    --color-destructive: var(--destructive);
+    --color-border: var(--border);
+    --color-input: var(--input);
+    --color-ring: var(--ring);
+    --color-chart-1: var(--chart-1);
+    --color-chart-2: var(--chart-2);
+    --color-chart-3: var(--chart-3);
+    --color-chart-4: var(--chart-4);
+    --color-chart-5: var(--chart-5);
+    --color-sidebar: var(--sidebar);
+    --color-sidebar-foreground: var(--sidebar-foreground);
+    --color-sidebar-primary: var(--sidebar-primary);
+    --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+    --color-sidebar-accent: var(--sidebar-accent);
+    --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+    --color-sidebar-border: var(--sidebar-border);
+    --color-sidebar-ring: var(--sidebar-ring);
+}
+
+  :root {
+    --radius: 0.625rem;
+    --background: oklch(1 0 0);
+    --foreground: oklch(0.145 0 0);
+    --card: oklch(1 0 0);
+    --card-foreground: oklch(0.145 0 0);
+    --popover: oklch(1 0 0);
+    --popover-foreground: oklch(0.145 0 0);
+    --primary: oklch(0.205 0 0);
+    --primary-foreground: oklch(0.985 0 0);
+    --secondary: oklch(0.97 0 0);
+    --secondary-foreground: oklch(0.205 0 0);
+    --muted: oklch(0.97 0 0);
+    --muted-foreground: oklch(0.556 0 0);
+    --accent: oklch(0.97 0 0);
+    --accent-foreground: oklch(0.205 0 0);
+    --destructive: oklch(0.577 0.245 27.325);
+    --border: oklch(0.922 0 0);
+    --input: oklch(0.922 0 0);
+    --ring: oklch(0.708 0 0);
+    --chart-1: oklch(0.646 0.222 41.116);
+    --chart-2: oklch(0.6 0.118 184.704);
+    --chart-3: oklch(0.398 0.07 227.392);
+    --chart-4: oklch(0.828 0.189 84.429);
+    --chart-5: oklch(0.769 0.188 70.08);
+    --sidebar: oklch(0.985 0 0);
+    --sidebar-foreground: oklch(0.145 0 0);
+    --sidebar-primary: oklch(0.205 0 0);
+    --sidebar-primary-foreground: oklch(0.985 0 0);
+    --sidebar-accent: oklch(0.97 0 0);
+    --sidebar-accent-foreground: oklch(0.205 0 0);
+    --sidebar-border: oklch(0.922 0 0);
+    --sidebar-ring: oklch(0.708 0 0);
+}
+
+  .dark {
+    --background: oklch(0.145 0 0);
+    --foreground: oklch(0.985 0 0);
+    --card: oklch(0.205 0 0);
+    --card-foreground: oklch(0.985 0 0);
+    --popover: oklch(0.205 0 0);
+    --popover-foreground: oklch(0.985 0 0);
+    --primary: oklch(0.922 0 0);
+    --primary-foreground: oklch(0.205 0 0);
+    --secondary: oklch(0.269 0 0);
+    --secondary-foreground: oklch(0.985 0 0);
+    --muted: oklch(0.269 0 0);
+    --muted-foreground: oklch(0.708 0 0);
+    --accent: oklch(0.269 0 0);
+    --accent-foreground: oklch(0.985 0 0);
+    --destructive: oklch(0.704 0.191 22.216);
+    --border: oklch(1 0 0 / 10%);
+    --input: oklch(1 0 0 / 15%);
+    --ring: oklch(0.556 0 0);
+    --chart-1: oklch(0.488 0.243 264.376);
+    --chart-2: oklch(0.696 0.17 162.48);
+    --chart-3: oklch(0.769 0.188 70.08);
+    --chart-4: oklch(0.627 0.265 303.9);
+    --chart-5: oklch(0.645 0.246 16.439);
+    --sidebar: oklch(0.205 0 0);
+    --sidebar-foreground: oklch(0.985 0 0);
+    --sidebar-primary: oklch(0.488 0.243 264.376);
+    --sidebar-primary-foreground: oklch(0.985 0 0);
+    --sidebar-accent: oklch(0.269 0 0);
+    --sidebar-accent-foreground: oklch(0.985 0 0);
+    --sidebar-border: oklch(1 0 0 / 10%);
+    --sidebar-ring: oklch(0.556 0 0);
+}
+
+  @layer base {
+  * {
+    @apply border-border outline-ring/50;
+    }
+  body {
+    @apply bg-background text-foreground;
+    }
+}
   

--- a/src/components/register/EventCard.tsx
+++ b/src/components/register/EventCard.tsx
@@ -1,0 +1,49 @@
+import { Switch } from "@/components/ui/switch";
+
+type Props = {
+  name: string;
+  isRegistered: boolean;
+  selected: boolean;
+  onToggle: (checked: boolean) => void;
+};
+
+export default function EventToggleCard({
+  name,
+  isRegistered,
+  selected,
+  onToggle,
+}: Props) {
+  return (
+    <div
+      className="py-4 px-2 flex flex-col"
+      style={{
+        borderBottomWidth: "2px",
+        borderBottomStyle: "solid",
+        borderImageSlice: 1,
+        borderImageSource: "linear-gradient(to right, #14b8a6, #3b82f6)", // teal-500 to blue-600
+      }}
+    >
+      <div className="flex justify-between items-center">
+        <span
+          className="text-2xl sm:text-5xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-teal-500 to-blue-600"
+          style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
+        >
+          {name}
+        </span>
+        <Switch
+          checked={selected}
+          onCheckedChange={onToggle}
+          disabled={isRegistered}
+        />
+      </div>
+      {isRegistered && (
+        <p
+          className="text-xl text-muted-foreground mt-1"
+          style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
+        >
+          ✅ You have already registered for this event.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import * as SwitchPrimitive from "@radix-ui/react-switch"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
+        )}
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}


### PR DESCRIPTION
1. Middleware redesign: verify JWT token in middleware instead of off-loading to verify-token
2. Handle error cases in /register route
3. Add stylings to pages under construction
4. Minimal config file fixes: Auto generated
5. All APIs to create JWT token using all user params
6. Move to jose to verify JWT from jsonwebtoken
     