### PR TITLE
Habya 2025: add empty cart modal and enable dark theme for hamburger menu

### DIFF
--- a/src/app/cart/summary/page.tsx
+++ b/src/app/cart/summary/page.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect } from "react";
+import { useSelector, useDispatch } from "react-redux";
+import type { RootState } from "@/store/store";
+import {
+  loadCartFromLocalStorage,
+  removeItem,
+  saveCartToLocalStorage,
+  setCart,
+} from "@/store/slices/cartSlice";
+import Navbar from "@/components/navbar/Navbar";
+import { useRouter } from "next/navigation";
+
+export default function CartPage() {
+  const user = useSelector((state: RootState) => state.user.user);
+  const cartItems = useSelector((state: RootState) => state.cart.items);
+  const dispatch = useDispatch();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (user?.id) {
+      const restoredCart = loadCartFromLocalStorage(user.id);
+      dispatch(setCart(restoredCart));
+    }
+  }, [user?.id, dispatch]);
+
+  const handleRemove = (id: string) => {
+    dispatch(removeItem(id));
+    if (user?.id) {
+      const updatedItems = cartItems.filter((i) => i.id !== id);
+      saveCartToLocalStorage(user.id, { items: updatedItems });
+    }
+  };
+
+  const total = cartItems.reduce(
+    (sum, item) => sum + item.price * item.quantity,
+    0
+  );
+
+  return (
+    <div className="min-h-screen bg-gradient-to-r from-gray-900 via-black to-gray-800 text-white transition-all duration-1000 ease-in-out">
+      <Navbar />
+
+      <div className="max-w-3xl mx-auto px-4 py-12">
+        <h1
+          className="text-3xl sm:text-6xl font-bold text-center text-transparent bg-clip-text bg-gradient-to-r from-teal-500 to-blue-600 mb-10 leading-tight"
+          style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
+        >
+          Your Cart Summary
+        </h1>
+
+        {cartItems.length === 0 ? (
+          <p className="text-center text-gray-400 text-lg italic">
+            🛒 Your cart is empty. Add some events to proceed!
+          </p>
+        ) : (
+          <>
+            <div className="space-y-6">
+              {cartItems.map((item) => (
+                <div
+                  key={item.id}
+                  className="px-2 py-4 flex justify-between items-start"
+                  style={{
+                    borderBottomWidth: "2px",
+                    borderBottomStyle: "solid",
+                    borderImageSlice: 1,
+                    borderImageSource:
+                      "linear-gradient(to right, #14b8a6, #3b82f6)", // teal-500 to blue-600
+                  }}
+                >
+                  <div>
+                    <h2
+                      className="text-2xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-teal-500 to-blue-600"
+                      style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
+                    >
+                      {item.name}
+                    </h2>
+
+                    {item.partner && (
+                      <p
+                        className="text-sm italic text-gray-300 mt-1"
+                        style={{
+                          fontFamily: "'Alumni Sans Pinstripe', cursive",
+                        }}
+                      >
+                        Partner: {item.partner.name}
+                      </p>
+                    )}
+
+                    <p
+                      className="text-sm text-gray-400 mt-1"
+                      style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
+                    >
+                      ₹{item.price}
+                    </p>
+                  </div>
+
+                  <button
+                    onClick={() => handleRemove(item.id)}
+                    className="text-sm text-red-400 hover:text-red-200 transition"
+                    style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
+                  >
+                    Remove
+                  </button>
+                </div>
+              ))}
+            </div>
+
+            {/* Total */}
+            <div className="mt-10 text-right">
+              <p className="text-xl text-gray-200">
+                Total:{" "}
+                <span className="text-transparent bg-clip-text bg-gradient-to-r from-teal-400 to-blue-500 font-bold">
+                  ₹{total}
+                </span>
+              </p>
+            </div>
+
+            {/* Proceed to Payment */}
+            <div className="mt-6 text-center">
+              <button
+                onClick={() => router.push("/payment")}
+                className="relative inline-block px-6 py-2 rounded-md text-lg font-semibold transition-all duration-300 hover:scale-105"
+                style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
+              >
+                <span className="absolute inset-0 rounded-md p-[2px] bg-gradient-to-r from-teal-500 to-blue-600"></span>
+                <span className="relative block bg-gray-900 rounded-md text-white">
+                  Proceed to Payment
+                </span>
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/cart/summary/page.tsx
+++ b/src/app/cart/summary/page.tsx
@@ -39,7 +39,7 @@ export default function CartPage() {
   );
 
   return (
-    <div className="min-h-screen bg-gradient-to-r from-gray-900 via-black to-gray-800 text-white transition-all duration-1000 ease-in-out">
+    <div className="min-h-screen bg-gradient-to-r from-gray-900 via-black to-gray-900 text-white transition-all duration-1000 ease-in-out">
       <Navbar />
 
       <div className="max-w-3xl mx-auto px-4 py-12">
@@ -66,12 +66,12 @@ export default function CartPage() {
                     borderBottomStyle: "solid",
                     borderImageSlice: 1,
                     borderImageSource:
-                      "linear-gradient(to right, #14b8a6, #3b82f6)", // teal-500 to blue-600
+                      "linear-gradient(to right, #14b8a6, #3b82f6)",
                   }}
                 >
                   <div>
                     <h2
-                      className="text-2xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-teal-500 to-blue-600"
+                      className="text-3xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-teal-500 to-blue-600"
                       style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
                     >
                       {item.name}
@@ -79,7 +79,7 @@ export default function CartPage() {
 
                     {item.partner && (
                       <p
-                        className="text-sm italic text-gray-300 mt-1"
+                        className="text-2xl text-white mt-2"
                         style={{
                           fontFamily: "'Alumni Sans Pinstripe', cursive",
                         }}
@@ -89,7 +89,7 @@ export default function CartPage() {
                     )}
 
                     <p
-                      className="text-sm text-gray-400 mt-1"
+                      className="text-lg text-white mt-1"
                       style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
                     >
                       ₹{item.price}
@@ -98,7 +98,7 @@ export default function CartPage() {
 
                   <button
                     onClick={() => handleRemove(item.id)}
-                    className="text-sm text-red-400 hover:text-red-200 transition"
+                    className="text-2xl text-red-400 hover:text-red-200 transition"
                     style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
                   >
                     Remove
@@ -108,12 +108,12 @@ export default function CartPage() {
             </div>
 
             {/* Total */}
-            <div className="mt-10 text-right">
-              <p className="text-xl text-gray-200">
-                Total:{" "}
-                <span className="text-transparent bg-clip-text bg-gradient-to-r from-teal-400 to-blue-500 font-bold">
-                  ₹{total}
-                </span>
+            <div className="mt-10 text-center">
+              <p
+                className="text-2xl font-bold text-white"
+                style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
+              >
+                Total: ₹{total}
               </p>
             </div>
 
@@ -121,11 +121,18 @@ export default function CartPage() {
             <div className="mt-6 text-center">
               <button
                 onClick={() => router.push("/payment")}
-                className="relative inline-block px-6 py-2 rounded-md text-lg font-semibold transition-all duration-300 hover:scale-105"
-                style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
+                className="relative inline-flex items-center justify-center px-6 py-2 border-1 border-transparent rounded-full transition-all duration-300 hover:scale-105"
+                style={{
+                  fontFamily: "'Alumni Sans Pinstripe', cursive",
+                  borderImageSlice: 1,
+                  borderImageSource:
+                    "linear-gradient(to right, #14b8a6, #3b82f6)",
+                }}
               >
-                <span className="absolute inset-0 rounded-md p-[2px] bg-gradient-to-r from-teal-500 to-blue-600"></span>
-                <span className="relative block bg-gray-900 rounded-md text-white">
+                <span
+                  className="text-transparent bg-clip-text bg-gradient-to-r from-teal-500 to-blue-600 text-2xl sm:text-3xl font-extrabold"
+                  style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
+                >
                   Proceed to Payment
                 </span>
               </button>

--- a/src/app/menu/register/page.tsx
+++ b/src/app/menu/register/page.tsx
@@ -19,6 +19,7 @@ import { RootState } from "@/store/store";
 import { eventRules } from "@/lib/events-utils/eventRules";
 import { validateTeamEligibility } from "@/lib/cart-utils/cartEligibility";
 import { fetchPartnerDetails } from "./utils/fetchPartner";
+import { useRouter } from "next/navigation";
 
 type Event = {
   id: string;
@@ -28,12 +29,14 @@ type Event = {
 
 export default function EventsPage() {
   const dispatch = useDispatch();
+  const router = useRouter();
   const cartItems = useSelector((state: RootState) => state.cart.items);
   const user = useSelector((state: RootState) => state.user.user);
 
   const [events, setEvents] = useState<Event[] | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
+  const [showCartEmptyModal, setShowCartEmptyModal] = useState(false);
 
   const [showPartnerModal, setShowPartnerModal] = useState(false);
   const [modalEvent, setModalEvent] = useState<Event | null>(null);
@@ -87,7 +90,7 @@ export default function EventsPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-r from-gray-900 via-black to-gray-800 text-white transition-all duration-1000 ease-in-out">
+    <div className="min-h-screen bg-gradient-to-r from-gray-900 via-black to-gray-900 text-white transition-all duration-1000 ease-in-out">
       <Navbar />
 
       <div className="max-w-3xl mx-auto px-4 py-12">
@@ -195,7 +198,7 @@ export default function EventsPage() {
                     }}
                   />
                   <p
-                    className={`text-xl text-muted-foreground mt-1 transition-all duration-700 ease-in-out`}
+                    className={`text-xl text-white mt-1 transition-all duration-700 ease-in-out`}
                     style={{
                       fontFamily: "'Alumni Sans Pinstripe', cursive",
                       opacity: isSelectedInCart ? 1 : 0,
@@ -211,31 +214,96 @@ export default function EventsPage() {
                 </div>
               );
             })}
+            <div className="mt-12 text-center">
+              <button
+                onClick={() => {
+                  if (cartItems.length === 0) {
+                    setShowCartEmptyModal(true);
+                    return;
+                  }
+                  router.push("/cart/summary");
+                }}
+                className="relative inline-flex items-center justify-center px-6 py-2 border-1 border-transparent rounded-full transition-all duration-300 hover:scale-105"
+                style={{
+                  fontFamily: "'Alumni Sans Pinstripe', cursive",
+                  borderImageSlice: 1,
+                  borderImageSource:
+                    "linear-gradient(to right, #14b8a6, #3b82f6)",
+                }}
+              >
+                <span
+                  className="text-transparent bg-clip-text bg-gradient-to-r from-teal-500 to-blue-600 text-2xl sm:text-3xl font-extrabold"
+                  style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
+                >
+                  Proceed to Cart
+                </span>
+              </button>
+            </div>
           </div>
         )}
       </div>
 
-      {/* Modal remains unchanged */}
-      {showPartnerModal && modalEvent && (
-        <div
-          className="fixed inset-0 flex items-center justify-center z-50 transition-all duration-1000 ease-in-out"
-          style={{
-            background: "linear-gradient(to right, #1f2937, #000000, #1f2937)",
-          }}
-        >
+      {showCartEmptyModal && (
+        <div className="fixed inset-0 flex items-center justify-center z-50 transition-all duration-1000 ease-in-out bg-gradient-to-r from-gray-900 via-black to-gray-900">
           <div
-            className="rounded-lg p-6 max-w-sm w-full shadow-lg border border-gray-700"
+            className="rounded-lg p-6 max-w-sm w-full mx-4 shadow-lg bg-gradient-to-r from-gray-900 via-black to-gray-900"
             style={{
-              background:
-                "linear-gradient(to right, #1f2937, #000000, #1f2937)",
+              borderWidth: "2px",
+              borderStyle: "solid",
+              borderImageSlice: 1,
+              borderImageSource: "linear-gradient(to right, #14b8a6, #3b82f6)", // teal to blue gradient
             }}
           >
             <h2
-              className="text-xl font-semibold mb-4 text-transparent bg-clip-text text-center"
-              style={{
-                fontFamily: "'Alumni Sans Pinstripe', cursive",
-                backgroundImage: "linear-gradient(to right, #14b8a6, #3b82f6)",
-              }}
+              className="text-transparent bg-clip-text bg-gradient-to-r from-teal-500 to-blue-600 text-3xl sm:text-3xl font-extrabold text-center mb-4"
+              style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
+            >
+              Please select at least one event
+            </h2>
+
+            <p
+              className="text-2xl text-center text-gray-300 mb-4"
+              style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
+            >
+              Your cart is currently empty. Add an event to continue.
+            </p>
+
+            <div className="flex justify-center">
+              <button
+                onClick={() => setShowCartEmptyModal(false)}
+                className="relative inline-flex items-center justify-center px-4 border-1 border-transparent rounded-full transition-all duration-300 hover:scale-105"
+                style={{
+                  fontFamily: "'Alumni Sans Pinstripe', cursive",
+                  borderImageSlice: 1,
+                  borderImageSource:
+                    "linear-gradient(to right, #14b8a6, #3b82f6)",
+                }}
+              >
+                <span
+                  className="text-transparent bg-clip-text bg-gradient-to-r from-teal-500 to-blue-600 text-xl sm:text-2xl font-extrabold"
+                  style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
+                >
+                  OK
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Modal remains unchanged */}
+      {showPartnerModal && modalEvent && (
+        <div className="fixed inset-0 flex items-center justify-center z-50 bg-gradient-to-r from-gray-900 via-black to-gray-900 text-white transition-all duration-1000 ease-in-out">
+          <div
+            className="rounded-lg p-6 max-w-sm w-full mx-4 shadow-lg border-2 border-transparent bg-gradient-to-r from-gray-900 via-black to-gray-900"
+            style={{
+              borderImageSlice: 1,
+              borderImageSource: "linear-gradient(to right, #14b8a6, #3b82f6)",
+            }}
+          >
+            <h2
+              className="text-2xl font-semibold mb-4 text-center text-white"
+              style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
             >
               Profile ID of your partner for {modalEvent.name}
             </h2>
@@ -348,26 +416,37 @@ export default function EventsPage() {
 
             <div className="flex justify-center space-x-3 mt-4">
               <button
-                className="px-4 py-2 rounded text-white transition"
-                style={{ backgroundColor: "rgba(75, 85, 99, 0.8)" }}
                 onClick={() => {
                   setShowPartnerModal(false);
                   setPartnerId("");
                   setPartnerIdError("");
                   setModalEvent(null);
                 }}
+                className="relative inline-flex items-center justify-center px-4 border-1 border-transparent rounded-full transition-all duration-300 hover:scale-105"
+                style={{
+                  fontFamily: "'Alumni Sans Pinstripe', cursive",
+                  borderImageSlice: 1,
+                  borderImageSource:
+                    "linear-gradient(to right, #14b8a6, #3b82f6)",
+                }}
               >
-                Cancel
+                <span
+                  className="text-white text-2xl sm:text-3xl font-extrabold"
+                  style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
+                >
+                  Cancel
+                </span>
               </button>
 
               <button
-                className="px-4 py-2 rounded text-white transition disabled:opacity-50 active:scale-95"
-                disabled={!partnerId.trim() || validating}
+                className="relative inline-flex items-center justify-center px-4 border-1 border-transparent rounded-full transition-all duration-300 hover:scale-105 disabled:opacity-50 active:scale-95"
                 style={{
-                  backgroundImage:
+                  fontFamily: "'Alumni Sans Pinstripe', cursive",
+                  borderImageSlice: 1,
+                  borderImageSource:
                     "linear-gradient(to right, #14b8a6, #3b82f6)",
-                  border: "none",
                 }}
+                disabled={!partnerId.trim() || validating}
                 onClick={async () => {
                   setValidating(true);
                   setPartnerIdError("");
@@ -437,7 +516,12 @@ export default function EventsPage() {
                   setValidating(false);
                 }}
               >
-                Submit
+                <span
+                  className="text-white text-2xl sm:text-3xl font-extrabold"
+                  style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
+                >
+                  Submit
+                </span>
               </button>
             </div>
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ export default function Home() {
   );
 
   return (
-    <div className="min-h-screen bg-gradient-to-r from-gray-900 via-black to-gray-800 text-white transition-all duration-1000 ease-in-out">
+    <div className="min-h-screen bg-gradient-to-r from-gray-900 via-black to-gray-900 text-white transition-all duration-1000 ease-in-out">
       <Navbar />
       <div className="flex flex-col justify-center items-center h-screen px-6 sm:px-12 md:px-16 lg:px-24">
         {isAuthenticated && user?.name ? (

--- a/src/app/sign-in/page.tsx
+++ b/src/app/sign-in/page.tsx
@@ -190,7 +190,16 @@ export default function SignIn() {
       </Head>
 
       <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-teal-100 to-blue-200 px-4 py-10">
-        <div className="max-w-md w-full bg-white rounded-xl shadow-md p-6 space-y-6">
+        <div
+          className="max-w-md w-full rounded-full p-8 space-y-6"
+          style={{
+            borderWidth: "2px",
+            borderStyle: "solid",
+            borderRadius: "0.375rem", // Tailwind 'rounded-md' is 6px = 0.375rem
+            borderImageSlice: 1,
+            borderImageSource: "linear-gradient(to right, #14b8a6, #3b82f6)", // teal to blue gradient
+          }}
+        >
           <h1 className="text-3xl font-bold text-center text-transparent bg-clip-text bg-gradient-to-r from-teal-500 to-blue-600">
             Sign Up
           </h1>

--- a/src/components/menu/register/EventCard.tsx
+++ b/src/components/menu/register/EventCard.tsx
@@ -14,12 +14,10 @@ export default function EventToggleCard({
   onToggle,
 }: Props) {
   return (
-    <div
-      className="flex flex-col"
-    >
+    <div className="flex flex-col">
       <div className="flex justify-between items-center">
         <span
-          className="text-2xl sm:text-5xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-teal-500 to-blue-600"
+          className="text-3xl sm:text-5xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-teal-500 to-blue-600"
           style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
         >
           {name}
@@ -33,7 +31,7 @@ export default function EventToggleCard({
       </div>
       {isRegistered && (
         <p
-          className="text-xl text-muted-foreground mt-1"
+          className="text-xl text-white mt-1"
           style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
         >
           You have already registered for this event.

--- a/src/components/navbar/HamburgerMenu.tsx
+++ b/src/components/navbar/HamburgerMenu.tsx
@@ -44,7 +44,7 @@ const HamburgerMenu = () => {
             <motion.div
               key="overlay"
               initial={{ opacity: 0 }}
-              animate={{ opacity: 0.6 }}
+              animate={{ opacity: 0.8 }}
               exit={{ opacity: 0 }}
               transition={{ duration: 0.2 }}
               className="fixed inset-0 bg-black z-40"
@@ -58,13 +58,13 @@ const HamburgerMenu = () => {
               animate={{ x: 0 }}
               exit={{ x: "100%" }}
               transition={{ type: "spring", stiffness: 300, damping: 30 }}
-              className="fixed top-0 right-0 h-full w-72 bg-gradient-to-r from-teal-100 to-blue-200 shadow-xl z-50 p-6 flex flex-col text-gray-800"
+              className="fixed top-0 right-0 h-full w-72 bg-gradient-to-r from-gray-900 via-black to-gray-900 shadow-xl z-50 p-6 flex flex-col text-white"
             >
               {/* Close icon */}
               <div className="flex justify-end mb-4">
                 <button
                   onClick={() => setOpen(false)}
-                  className="text-gray-700 hover:text-teal-600"
+                  className="text-white"
                 >
                   <X className="w-6 h-6" />
                 </button>
@@ -72,11 +72,11 @@ const HamburgerMenu = () => {
 
               {/* Menu items */}
               <ul className="flex flex-col divide-y divide-teal-300 text-base font-medium">
-              <li className="py-3">
+                <li className="py-3">
                   <Link href="/" onClick={() => setOpen(false)}>
                     <span
                       style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
-                      className="text-2xl bg-clip-text text-transparent bg-gradient-to-r from-teal-800 to-blue-900"
+                      className="text-2xl"
                     >
                       Home
                     </span>
@@ -86,7 +86,7 @@ const HamburgerMenu = () => {
                   <Link href="/menu/register" onClick={() => setOpen(false)}>
                     <span
                       style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
-                      className="text-2xl bg-clip-text text-transparent bg-gradient-to-r from-teal-800 to-blue-900"
+                      className="text-2xl"
                     >
                       Register
                     </span>
@@ -96,17 +96,20 @@ const HamburgerMenu = () => {
                   <Link href="/menu/sponsor" onClick={() => setOpen(false)}>
                     <span
                       style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
-                      className="text-2xl bg-clip-text text-transparent bg-gradient-to-r from-teal-800 to-blue-900"
+                      className="text-2xl"
                     >
                       Sponsor
                     </span>
                   </Link>
                 </li>
                 <li className="py-3">
-                  <Link href="/menu/my-registrations" onClick={() => setOpen(false)}>
+                  <Link
+                    href="/menu/my-registrations"
+                    onClick={() => setOpen(false)}
+                  >
                     <span
                       style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
-                      className="text-2xl bg-clip-text text-transparent bg-gradient-to-r from-teal-800 to-blue-900"
+                      className="text-2xl"
                     >
                       My Registrations
                     </span>
@@ -116,7 +119,7 @@ const HamburgerMenu = () => {
                   <Link href="/menu/buy-food" onClick={() => setOpen(false)}>
                     <span
                       style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
-                      className="text-2xl bg-clip-text text-transparent bg-gradient-to-r from-teal-800 to-blue-900"
+                      className="text-2xl"
                     >
                       Buy Food Coupons
                     </span>
@@ -126,7 +129,7 @@ const HamburgerMenu = () => {
                   <Link href="/menu/buy-shirt" onClick={() => setOpen(false)}>
                     <span
                       style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
-                      className="text-2xl bg-clip-text text-transparent bg-gradient-to-r from-teal-800 to-blue-900"
+                      className="text-2xl"
                     >
                       Buy Shirt
                     </span>
@@ -142,7 +145,7 @@ const HamburgerMenu = () => {
                   >
                     <span
                       style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
-                      className="text-2xl bg-clip-text text-transparent bg-gradient-to-r from-teal-800 to-blue-900"
+                      className="text-2xl"
                     >
                       Logout
                     </span>

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -1,10 +1,8 @@
 "use client";
 
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import Link from "next/link";
 import { RootState } from "@/store/store";
-import { setAuthenticated } from "@/store/slices/authSlice";
-import { useRouter } from "next/navigation";
 import HamburgerMenu from "./HamburgerMenu";
 
 const Navbar = () => {
@@ -21,18 +19,30 @@ const Navbar = () => {
           className="text-2xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-teal-500 to-blue-600"
         >
           <h2
-              className="text-4xl sm:text-6xl md:text-7xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-teal-500 to-blue-600 text-center leading-tight"
-              style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
-            >
-              Habya 2025
-            </h2>
+            className="text-4xl sm:text-6xl md:text-7xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-teal-500 to-blue-600 text-center leading-tight"
+            style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
+          >
+            Habya 2025
+          </h2>
         </Link>
 
         {!isAuthenticated ? (
           <Link href="/sign-in">
-            <button className="relative inline-flex items-center justify-center px-5 py-2.5 overflow-hidden font-medium text-teal-800 transition duration-300 ease-out border border-teal-300 rounded-full shadow-md group hover:shadow-lg hover:bg-teal-50">
-              <span className="absolute inset-0 w-full h-full bg-gradient-to-br from-teal-100 to-white opacity-50 group-hover:opacity-80 rounded-full blur-sm"></span>
-              <span className="relative z-10">Login</span>
+            <button
+              className="relative inline-flex items-center justify-center px-4 border-1 border-transparent rounded-full transition-all duration-300 hover:scale-105"
+              style={{
+                fontFamily: "'Alumni Sans Pinstripe', cursive",
+                borderImageSlice: 1,
+                borderImageSource:
+                  "linear-gradient(to right, #14b8a6, #3b82f6)",
+              }}
+            >
+              <span
+                className="text-transparent bg-clip-text bg-gradient-to-r from-teal-500 to-blue-600 text-2xl sm:text-4xl font-extrabold"
+                style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
+              >
+                Login
+              </span>
             </button>
           </Link>
         ) : (

--- a/src/lib/cart-utils/cartEligibility.ts
+++ b/src/lib/cart-utils/cartEligibility.ts
@@ -23,15 +23,31 @@ export function validateTeamEligibility(
     return teamEligibility;
   }
 
-  const totalPartnerEvents = new Set([
-    ...partnerRegistrations,
-    ...cartItems
-      .filter((item) => item.partner?.id === partner.id)
-      .map((item) => Number(item.id)),
-  ]).size;
+  const eventId = Number(event.id);
 
-  if (totalPartnerEvents >= 3) {
-    return `${partner.name} has already registered for 3 events.`;
+  // Partner DB registrations
+  const dbRegisteredEventIds = new Set(partnerRegistrations);
+
+  if (dbRegisteredEventIds.has(eventId)) {
+    return `Sorry, ${partner.name} is already booked for this event. You'll have to crash another party!`;
+  }
+
+  const cartEventIds = new Set(
+    cartItems
+      .filter((item) => item.partner?.id === partner.id)
+      .map((item) => Number(item.id))
+  );
+
+  const totalUniqueEvents = new Set([...dbRegisteredEventIds, ...cartEventIds]);
+
+  if (totalUniqueEvents.size >= 3) {
+    const dbCount = dbRegisteredEventIds.size;
+    const cartCount = cartEventIds.size;
+    if (dbCount >= 3) {
+      return `${partner.name} has already registered for 3 events.`;
+    } else {
+      return `${partner.name} has already registered for ${dbCount} events and has ${cartCount} in your cart. Adding this will exceed the 3-event limit for your partner.`;
+    }
   }
 
   return null;

--- a/src/lib/events-utils/eligibilityUtils.ts
+++ b/src/lib/events-utils/eligibilityUtils.ts
@@ -62,6 +62,10 @@ export function isTeamEligible(
     return "This event is not for teams.";
   }
 
+  if(Number(p1.id) === Number(p2.id)){
+    return `Come on! You can not partner with yourself! Enter a correct profile ID`;
+  }
+
   const teamGenders = [p1.gender, p2.gender].map((g) => g.toLowerCase()).sort();
   const allowed = [...event.allowedGenders].sort();
 


### PR DESCRIPTION
1. Show empty cart modal when user tries to access cart summary page when cart is empty
2. Enable dark theme for hamburger menu, in alignment with home page styles
3. Fix buttons style to main consistency - Login button, buttons on show partner modal, buttons on show empty cart modal