### PR TITLE
Habya 2025: Restructure cart items to accommodate multiple shirts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,8 @@
         "react-hot-toast": "^2.5.2",
         "react-icons": "^5.5.0",
         "react-redux": "^9.2.0",
-        "tailwind-merge": "^3.3.0"
+        "tailwind-merge": "^3.3.0",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "react-hot-toast": "^2.5.2",
     "react-icons": "^5.5.0",
     "react-redux": "^9.2.0",
-    "tailwind-merge": "^3.3.0"
+    "tailwind-merge": "^3.3.0",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/cart/summary/page.tsx
+++ b/src/app/cart/summary/page.tsx
@@ -97,6 +97,23 @@ export default function CartPage() {
                         </p>
                       )}
 
+                      {/* New: Show shirt details if present */}
+                      {item.shirtData && item.shirtData.length > 0 && (
+                        <div
+                          className="text-white mt-2"
+                          style={{
+                            fontFamily: "'Alumni Sans Pinstripe', cursive",
+                          }}
+                        >
+                          {item.shirtData.map((shirt, idx) => (
+                            <p key={idx} className="text-lg">
+                              {shirt.name ? `Name: ${shirt.name}, ` : ""}
+                              Size: {shirt.size}
+                            </p>
+                          ))}
+                        </div>
+                      )}
+
                       <p
                         className="text-lg text-white mt-1"
                         style={{


### PR DESCRIPTION
ShirtData used to contain multiple shirts in the same object with type: shirt - causing issues in cart summary page

1. Restructure cart items to accommodate each shirt added as a different item. 
2. Show name and size of shirts in the cart summary page