### PR TITLE
Habya 2025: integrate Twilio for OTP authentication

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-icons": "^5.5.0",
     "react-redux": "^9.2.0",
     "tailwind-merge": "^3.3.0",
+    "twilio": "^5.7.0",
     "uuid": "^11.1.0"
   },
   "devDependencies": {

--- a/src/app/api/auth/otp/send-otp/route.ts
+++ b/src/app/api/auth/otp/send-otp/route.ts
@@ -1,0 +1,25 @@
+// app/api/send-otp/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import twilio from "twilio";
+
+const client = twilio(
+  process.env.TWILIO_ACCOUNT_SID!,
+  process.env.TWILIO_AUTH_TOKEN!
+);
+
+export async function POST(req: NextRequest) {
+  const { phone } = await req.json();
+
+  try {
+    const verification = await client.verify
+      .v2.services(process.env.TWILIO_VERIFY_SERVICE_SID!)
+      .verifications.create({
+        to: `+91${phone}`,
+        channel: "sms",
+      });
+
+    return NextResponse.json({ success: true, sid: verification.sid });
+  } catch (err: any) {
+    return NextResponse.json({ success: false, error: err.message }, { status: 500 });
+  }
+}

--- a/src/app/api/auth/otp/verify-otp/route.ts
+++ b/src/app/api/auth/otp/verify-otp/route.ts
@@ -1,0 +1,30 @@
+// app/api/verify-otp/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import twilio from "twilio";
+
+const client = twilio(
+  process.env.TWILIO_ACCOUNT_SID!,
+  process.env.TWILIO_AUTH_TOKEN!
+);
+
+export async function POST(req: NextRequest) {
+  const { phone, otp } = await req.json();
+
+  try {
+    const verificationCheck = await client.verify
+      .v2.services(process.env.TWILIO_VERIFY_SERVICE_SID!)
+      .verificationChecks.create({
+        to: `+91${phone}`,
+        code: otp,
+      });
+
+    if (verificationCheck.status === "approved") {
+      // you can generate JWT here
+      return NextResponse.json({ success: true });
+    } else {
+      return NextResponse.json({ success: false, message: "Invalid OTP" });
+    }
+  } catch (err: any) {
+    return NextResponse.json({ success: false, error: err.message }, { status: 500 });
+  }
+}

--- a/src/app/menu/buy-shirt/page.tsx
+++ b/src/app/menu/buy-shirt/page.tsx
@@ -107,14 +107,14 @@ export default function BuyShirtPage() {
         </h1>
 
         <p
-          className="text-center text-2xl text-gray-300 mb-10"
+          className="text-center text-2xl text-white mb-10"
           style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
         >
-          Own a piece of the passion. Get your official{" "}
+          Get your official{" "}
           <span className="text-teal-400">Habya 2025</span> shirt for ₹500.
           <br />
           <span
-            className="text-transparent bg-clip-text bg-gradient-to-r from-teal-500 to-blue-600"
+            className="bg-clip-text text-white"
             style={{ display: "inline-block" }}
           >
             Style it. Sport it. Celebrate the game your way.


### PR DESCRIPTION
1. Enable /api/auth/otp/send-otp/route.ts and api/auth/otp/verify-otp/route.ts.
2. Re-write send OTP, verify OTP logic from /sign-in route in frontend. 