### PR TITLE
Habya 2025: fix send OTP layout and handle lengthy error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 17. Keep JWT secrets in secure place
 21. Validate OTP sending failed. 
 
-
+Bugs:
+1. Fix send OTP for other numbers
+2. Fix send OTP layout
+3. Fix edit-profile saving changes (profile state showing old data)
+4. DB actions are slow
 
 18. Add profile form redesign, Profile saved form redesign // Done
 19. Remove redirect page display for a public path.  // Done

--- a/src/components/sign-in/PhoneInput.tsx
+++ b/src/components/sign-in/PhoneInput.tsx
@@ -17,7 +17,7 @@ export default function PhoneInput({
 }: PhoneInputProps) {
   return (
     <>
-      <div>
+      <div className="w-full max-w-md mx-auto px-4">
         <span
           className="bg-clip-text text-white text-3xl font-extrabold pb-8"
           style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
@@ -62,7 +62,7 @@ export default function PhoneInput({
           />
         </div>
 
-        <div className="h-5 py-4">
+        <div className="py-4 min-h-[1.5rem]">
           {phoneError && (
             <p
               className="text-red-400 text-xl text-center"


### PR DESCRIPTION
1. While testing on Prod, it is found that send OTP layout is not responsive. Phone input box goes out of the screen
2. Also, when Twilio sends back a lengthy error message, the message is displayed behind the send OTP button. 