### PR TITLE
Habya 2025: enable admin dashboard - Coupons

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 17. Keep JWT secrets in secure place
 21. Validate OTP sending failed. 
 22. Add table for counter_coupons and handle the logic to redeem
+23. Dropdowns for t shirt details coming in white
 
 
 Bugs:

--- a/src/app/api/admin/coupons/couponUtils.ts
+++ b/src/app/api/admin/coupons/couponUtils.ts
@@ -1,0 +1,16 @@
+import prisma from "@/lib/prisma/prisma";
+import { CouponMeal, CouponStatus, CouponType } from "./types";
+
+export async function countCoupons(
+  meal: CouponMeal,
+  type: CouponType,
+  status: CouponStatus
+): Promise<number> {
+  return prisma.coupons.count({
+    where: {
+      meal,
+      type,
+      status,
+    },
+  });
+}

--- a/src/app/api/admin/coupons/route.ts
+++ b/src/app/api/admin/coupons/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import { jwtVerify } from "jose";
+import { countCoupons } from "./couponUtils";
+import { CouponSummaryResponse } from "./types";
+
+const JWT_SECRET = process.env.JWT_SECRET!;
+
+export async function GET(req: NextRequest) {
+  try {
+    const token = req.cookies.get("token")?.value;
+    if (!token) {
+      return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+    }
+
+    const encoder = new TextEncoder();
+    const { payload } = await jwtVerify(token, encoder.encode(JWT_SECRET));
+
+    if (payload.role !== "admin") {
+      return NextResponse.json(
+        {
+          message:
+            "You are not authorised to use this feature. Request the event organisers to add you as an admin. If you have been added as an admin, logout and login again",
+        },
+        { status: 403 }
+      );
+    }
+
+    const response: CouponSummaryResponse = {
+      lunchDefaultActive: await countCoupons("lunch", "default", "active"),
+      lunchBoughtActive: await countCoupons("lunch", "bought", "active"),
+      lunchDefaultRedeemed: await countCoupons("lunch", "default", "redeemed"),
+      lunchBoughtRedeemed: await countCoupons("lunch", "bought", "redeemed"),
+      snackDefaultActive: await countCoupons("snack", "default", "active"),
+      snackBoughtActive: await countCoupons("snack", "bought", "active"),
+      snackDefaultRedeemed: await countCoupons("snack", "default", "redeemed"),
+      snackBoughtRedeemed: await countCoupons("snack", "bought", "redeemed"),
+    };
+
+    return NextResponse.json(response);
+  } catch (err: unknown) {
+    const error = err instanceof Error ? err : new Error("Unknown error");
+    return NextResponse.json(
+      { message: "Internal Server Error", error: error.message },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/admin/coupons/types.ts
+++ b/src/app/api/admin/coupons/types.ts
@@ -1,0 +1,14 @@
+export type CouponMeal = "lunch" | "snack";
+export type CouponType = "default" | "bought";
+export type CouponStatus = "active" | "redeemed";
+
+export interface CouponSummaryResponse {
+  lunchDefaultActive: number;
+  lunchBoughtActive: number;
+  lunchDefaultRedeemed: number;
+  lunchBoughtRedeemed: number;
+  snackDefaultActive: number;
+  snackBoughtActive: number;
+  snackDefaultRedeemed: number;
+  snackBoughtRedeemed: number;
+}

--- a/src/app/menu/admin/coupons/page.tsx
+++ b/src/app/menu/admin/coupons/page.tsx
@@ -1,44 +1,34 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Navbar from "@/components/navbar/Navbar";
 import { useSelector } from "react-redux";
 import { RootState } from "@/store/store";
-import {
-  Registration,
-  Stats,
-} from "@/components/menu/admin/registrations/types";
-import RegistrationsByEvent from "@/components/menu/admin/registrations/RegistrationsByEvent";
-import StatsTable from "@/components/menu/admin/registrations/StatsTable";
+import Navbar from "@/components/navbar/Navbar";
 import Unauthorized from "@/components/menu/admin/Unauthorized";
-import RegistrationsSummary from "@/components/menu/admin/registrations/RegistrationsSummary";
+import CouponSummary from "@/components/menu/admin/coupons/CouponSummary";
+import { CouponSummaryResponse } from "@/components/menu/admin/coupons/types";
 
-interface ApiResponse {
-  registrations: Registration[];
-  stats: Stats;
-}
-
-export default function AdminRegistrations() {
+export default function AdminCouponsPage() {
   const user = useSelector((state: RootState) => state.user.user);
   const isAdmin = user?.role === "admin";
 
-  const [data, setData] = useState<ApiResponse | null>(null);
+  const [summary, setSummary] = useState<CouponSummaryResponse | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const fetchData = async () => {
+    const fetchSummary = async () => {
       try {
-        const res = await fetch("/api/admin/registrations");
-        const json = await res.json();
-        setData(json);
+        const res = await fetch("/api/admin/coupons");
+        const data = await res.json();
+        setSummary(data);
       } catch (error) {
-        console.error("Failed to fetch registrations", error);
+        console.error("Failed to fetch coupon summary", error);
       } finally {
         setLoading(false);
       }
     };
 
-    if (isAdmin) fetchData();
+    if (isAdmin) fetchSummary();
   }, [isAdmin]);
 
   return (
@@ -49,7 +39,7 @@ export default function AdminRegistrations() {
           className="text-3xl font-bold text-center text-transparent bg-clip-text bg-gradient-to-r from-teal-400 to-blue-600 mb-12"
           style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
         >
-          Registrations Overview
+          Coupons Overview
         </h1>
 
         {!isAdmin ? (
@@ -58,18 +48,17 @@ export default function AdminRegistrations() {
           <div
             className="text-center text-3xl"
             style={{
-              borderImage: "linear-gradient(to right, #2dd4bf, #2563eb) 1",
               fontFamily: "'Alumni Sans Pinstripe', cursive",
             }}
           >
             Loading...
           </div>
+        ) : summary ? (
+          <CouponSummary summary={summary} />
         ) : (
-          <>
-            <RegistrationsSummary registrations={data!.registrations} />
-            <RegistrationsByEvent registrations={data!.registrations} />
-            <StatsTable stats={data!.stats} />
-          </>
+          <div className="text-center text-xl text-red-400">
+            Failed to load summary
+          </div>
         )}
       </div>
     </div>

--- a/src/components/menu/admin/coupons/CouponSummary.tsx
+++ b/src/components/menu/admin/coupons/CouponSummary.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import React from "react";
+import { CouponSummaryResponse } from "./types";
+
+export default function CouponSummary({
+  summary,
+}: {
+  summary: CouponSummaryResponse;
+}) {
+  const rows = [
+    {
+      label: "Lunch - Default",
+      active: summary.lunchDefaultActive,
+      redeemed: summary.lunchDefaultRedeemed,
+    },
+    {
+      label: "Lunch - Bought",
+      active: summary.lunchBoughtActive,
+      redeemed: summary.lunchBoughtRedeemed,
+    },
+    {
+      label: "Snack - Default",
+      active: summary.snackDefaultActive,
+      redeemed: summary.snackDefaultRedeemed,
+    },
+    {
+      label: "Snack - Bought",
+      active: summary.snackBoughtActive,
+      redeemed: summary.snackBoughtRedeemed,
+    },
+  ];
+
+  return (
+    <div
+      className="mb-10 overflow-x-auto rounded-xl border-1 p-4"
+      style={{
+        borderImage: "linear-gradient(to right, #2dd4bf, #2563eb) 1",
+        fontFamily: "'Alumni Sans Pinstripe', cursive",
+      }}
+    >
+      <h2 className="text-3xl font-bold text-center mb-4 text-transparent bg-clip-text bg-gradient-to-r from-teal-400 to-blue-600">
+        Coupon Summary
+      </h2>
+
+      <table className="min-w-full text-white text-center text-xl">
+        <thead>
+          <tr className="text-transparent bg-clip-text bg-gradient-to-r from-teal-600 to-blue-600 text-2xl bg-white/8 border border-white/8">
+            <th className="px-4 py-2">Category</th>
+            <th className="px-4 py-2">Active</th>
+            <th className="px-4 py-2">Redeemed</th>
+            <th className="px-4 py-2">Total</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, idx) => (
+            <tr
+              key={idx}
+              className={
+                idx % 2 === 0
+                  ? "bg-white/5 border-b border-white/10"
+                  : "bg-white/10 border-b border-white/10"
+              }
+            >
+              <td className="px-4 py-2">{row.label}</td>
+              <td className="px-4 py-2">{row.active}</td>
+              <td className="px-4 py-2">{row.redeemed}</td>
+              <td className="px-4 py-2">{row.active + row.redeemed}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/menu/admin/coupons/types.ts
+++ b/src/components/menu/admin/coupons/types.ts
@@ -1,0 +1,14 @@
+export type CouponMeal = "lunch" | "snack";
+export type CouponType = "default" | "bought";
+export type CouponStatus = "active" | "redeemed";
+
+export interface CouponSummaryResponse {
+  lunchDefaultActive: number;
+  lunchBoughtActive: number;
+  lunchDefaultRedeemed: number;
+  lunchBoughtRedeemed: number;
+  snackDefaultActive: number;
+  snackBoughtActive: number;
+  snackDefaultRedeemed: number;
+  snackBoughtRedeemed: number;
+}

--- a/src/components/menu/admin/registrations/RegistrationsByEvent.tsx
+++ b/src/components/menu/admin/registrations/RegistrationsByEvent.tsx
@@ -27,7 +27,7 @@ export default function RegistrationsByEvent({ registrations }: Props) {
   return (
     <div>
       <h2
-        className="text-3xl text-center mb-6 text-transparent bg-clip-text bg-gradient-to-r from-teal-400 to-blue-600"
+        className="text-3xl font-bold text-center mb-6 text-transparent bg-clip-text bg-gradient-to-r from-teal-400 to-blue-600"
         style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
       >
         Registrations by Event
@@ -40,7 +40,7 @@ export default function RegistrationsByEvent({ registrations }: Props) {
         return (
           <div
             key={eventId}
-            className="mb-6 border-2 rounded-lg overflow-hidden transition-all"
+            className="mb-6 border-b rounded-lg overflow-hidden transition-all"
             style={{
               borderImage: "linear-gradient(to right, #2dd4bf, #3b82f6) 1",
             }}
@@ -66,11 +66,11 @@ export default function RegistrationsByEvent({ registrations }: Props) {
                 isOpen ? "max-h-[1000px] opacity-100" : "max-h-0 opacity-0"
               }`}
             >
-              <div className="p-4 space-y-3">
+              <div className="p-2 space-y-3">
                 {regs.map((reg, idx) => (
                   <div
                     key={idx}
-                    className="p-3 rounded-md bg-gradient-to-r from-white/10 via-white/5 to-white/10"
+                    className="p-2 my-2 rounded-md bg-gradient-to-r from-white/10 via-white/5 to-white/10"
                     style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
                   >
                     <p className="text-2xl text-white">

--- a/src/components/menu/admin/registrations/RegistrationsSummary.tsx
+++ b/src/components/menu/admin/registrations/RegistrationsSummary.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import React from "react";
+import { Registration } from "./types";
+
+export default function RegistrationsSummary({
+  registrations,
+}: {
+  registrations: Registration[];
+}) {
+  const total = registrations.length;
+  const singles = registrations.filter((reg) => !reg.player2_name).length;
+  const doubles = total - singles;
+
+  return (
+    <div
+      className="mb-10 overflow-x-auto rounded-xl border-1 p-4"
+      style={{
+        borderImage: "linear-gradient(to right, #2dd4bf, #2563eb) 1",
+        fontFamily: "'Alumni Sans Pinstripe', cursive",
+      }}
+    >
+      <h2 className="text-3xl font-bold text-center mb-4 text-transparent bg-clip-text bg-gradient-to-r from-teal-400 to-blue-600">
+        Summary
+      </h2>
+
+      <table className="min-w-full text-white text-center text-xl">
+        <thead>
+          <tr className="text-transparent bg-clip-text bg-gradient-to-r from-teal-600 to-blue-600 text-2xl bg-white/8 border border-white/8">
+            <th className="px-4 py-2">Category</th>
+            <th className="px-4 py-2">Count</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr className="bg-white/5 ">
+            <td className="px-4 py-2">Singles</td>
+            <td className="px-4 py-2">{singles}</td>
+          </tr>
+          <tr className="bg-white/8 border-b border-white/8">
+            <td className="px-4 py-2">Doubles</td>
+            <td className="px-4 py-2">{doubles}</td>
+          </tr>
+          <tr className="bg-white/5 border-b border-white/10">
+            <td className="px-4 py-2">Total</td>
+            <td className="px-4 py-2">{total}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/menu/admin/registrations/StatsTable.tsx
+++ b/src/components/menu/admin/registrations/StatsTable.tsx
@@ -6,7 +6,7 @@ export default function StatsTable({ stats }: { stats: Stats }) {
   return (
     <div>
       <h2
-        className="text-3xl text-center mt-10 text-transparent bg-clip-text bg-gradient-to-r from-teal-400 to-blue-600"
+        className="text-3xl font-bold text-center mt-10 text-transparent bg-clip-text bg-gradient-to-r from-teal-400 to-blue-600"
         style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
       >
         Players with event count
@@ -19,7 +19,7 @@ export default function StatsTable({ stats }: { stats: Stats }) {
         three events and who are yet to register.
       </p>
       <div
-        className="mb-10 overflow-x-auto rounded-xl border-2"
+        className="mb-10 overflow-x-auto rounded-xl border-1"
         style={{
           borderImage: "linear-gradient(to right, #2dd4bf, #2563eb) 1",
           fontFamily: "'Alumni Sans Pinstripe', cursive",


### PR DESCRIPTION
1. Coupons API to fetch all coupons categorised based on lunch vs snack, default vs bought, active vs redeemed
2. Frontend route - Show coupons summary active vs redeemed for all types and meals