### PR TITLE
Habya 2025: Show registrations count in summary for admins

### DIFF
--- a/src/components/menu/admin/registrations/RegistrationsByEvent.tsx
+++ b/src/components/menu/admin/registrations/RegistrationsByEvent.tsx
@@ -30,7 +30,7 @@ export default function RegistrationsByEvent({ registrations }: Props) {
         className="text-3xl font-bold text-center mb-6 text-transparent bg-clip-text bg-gradient-to-r from-teal-400 to-blue-600"
         style={{ fontFamily: "'Alumni Sans Pinstripe', cursive" }}
       >
-        Registrations by Event
+        Registrations by Event ({registrations.length})
       </h2>
 
       {Object.entries(groupedByEvent).map(([eventIdStr, regs]) => {


### PR DESCRIPTION
So far only the list of each event showed the number of entries. Show the overall count too. 